### PR TITLE
Feature/store assoc new

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,8 +17,8 @@ System.config({
 
   map: {
     "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.2.1",
-    "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.4",
-    "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.5",
+    "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.5",
+    "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
     "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.1.4",
     "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0-beta.1.0.0",
     "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.2",
@@ -28,7 +28,7 @@ System.config({
     "core-js": "npm:core-js@1.2.6",
     "extend": "npm:extend@3.0.0",
     "fetch": "github:github/fetch@0.11.0",
-    "spoonx/aurelia-api": "github:spoonx/aurelia-api@2.0.7",
+    "spoonx/aurelia-api": "github:spoonx/aurelia-api@2.0.8",
     "typer": "npm:typer@1.1.0",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
@@ -42,8 +42,8 @@ System.config({
     "github:jspm/nodelibs-util@0.1.0": {
       "util": "npm:util@0.10.3"
     },
-    "github:spoonx/aurelia-api@2.0.7": {
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.4",
+    "github:spoonx/aurelia-api@2.0.8": {
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.5",
       "aurelia-fetch-client": "npm:aurelia-fetch-client@1.0.0-beta.1.1.1",
       "extend": "npm:extend@3.0.0",
       "qs": "npm:qs@6.1.0"
@@ -52,20 +52,20 @@ System.config({
       "util": "npm:util@0.10.3"
     },
     "npm:aurelia-binding@1.0.0-beta.1.2.1": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.5",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
       "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.1"
     },
-    "npm:aurelia-dependency-injection@1.0.0-beta.1.1.4": {
+    "npm:aurelia-dependency-injection@1.0.0-beta.1.1.5": {
       "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.5",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
     },
     "npm:aurelia-loader@1.0.0-beta.1.1.1": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.5",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
       "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.1"
     },
-    "npm:aurelia-metadata@1.0.0-beta.1.1.5": {
+    "npm:aurelia-metadata@1.0.0-beta.1.1.6": {
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
     },
     "npm:aurelia-pal-browser@1.0.0-beta.1.1.4": {
@@ -79,19 +79,19 @@ System.config({
     },
     "npm:aurelia-templating@1.0.0-beta.1.1.2": {
       "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.2.1",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.4",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.5",
       "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.1.1",
       "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.5",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
       "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.1",
       "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.1"
     },
     "npm:aurelia-validation@0.6.3": {
       "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.2.1",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.4",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.5",
       "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.5",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.6",
       "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.2"
     },
     "npm:babel-runtime@5.8.35": {

--- a/dist/amd/entity.js
+++ b/dist/amd/entity.js
@@ -106,17 +106,28 @@ define(['exports', 'aurelia-validation', 'aurelia-dependency-injection', './orm-
       key: 'addCollectionAssociation',
       value: function addCollectionAssociation(entity, property) {
         property = property || getPropertyForAssociation(this, entity);
-        var idToAdd = entity;
+        var body = undefined;
+        var url = [this.getResource(), this.id, property];
 
-        if (entity instanceof Entity) {
-          if (!entity.id) {
-            return Promise.resolve(null);
-          }
-
-          idToAdd = entity.id;
+        if (this.isNew()) {
+          throw new Error('Cannot add association to entity that does not have an id.');
         }
 
-        return this.getTransport().create([this.getResource(), this.id, property, idToAdd].join('/'));
+        if (!(entity instanceof Entity)) {
+          url.push(entity);
+
+          return this.getTransport().create(url.join('/'));
+        }
+
+        if (entity.isNew()) {
+          body = entity.asObject();
+        } else {
+          url.push(entity.id);
+        }
+
+        return this.getTransport().create(url.join('/'), body).then(function (created) {
+          return entity.setData(created).markClean();
+        });
       }
     }, {
       key: 'removeCollectionAssociation',

--- a/dist/commonjs/entity.js
+++ b/dist/commonjs/entity.js
@@ -111,17 +111,28 @@ var Entity = (function () {
     key: 'addCollectionAssociation',
     value: function addCollectionAssociation(entity, property) {
       property = property || getPropertyForAssociation(this, entity);
-      var idToAdd = entity;
+      var body = undefined;
+      var url = [this.getResource(), this.id, property];
 
-      if (entity instanceof Entity) {
-        if (!entity.id) {
-          return Promise.resolve(null);
-        }
-
-        idToAdd = entity.id;
+      if (this.isNew()) {
+        throw new Error('Cannot add association to entity that does not have an id.');
       }
 
-      return this.getTransport().create([this.getResource(), this.id, property, idToAdd].join('/'));
+      if (!(entity instanceof Entity)) {
+        url.push(entity);
+
+        return this.getTransport().create(url.join('/'));
+      }
+
+      if (entity.isNew()) {
+        body = entity.asObject();
+      } else {
+        url.push(entity.id);
+      }
+
+      return this.getTransport().create(url.join('/'), body).then(function (created) {
+        return entity.setData(created).markClean();
+      });
     }
   }, {
     key: 'removeCollectionAssociation',

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name"2.2.0"></a>
+## 2.2.0 (2016-03-05)
+
+
+#### Features
+
+* **entity:** Create child when new, upon adding ([a2ff99d9](https://github.com/SpoonX/aurelia-orm/commit/a2ff99d9))
+
+
 <a name"2.1.1"></a>
 ### 2.1.1 (2016-03-02)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-orm",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Makes working with entities and calling your Rest API simple.",
   "keywords": [
     "aurelia",


### PR DESCRIPTION
When adding a new association to the collection, normally you'd perform a POST to:

`/resource/:id/:collection/:collectionId`

While this works fine on linking existing entities, this causes problems when the entity is new. What this does, is change the route to `/resource/:id/:collection` and post the entity along with it, which causes a create _and_ link to occur.
