### PR TITLE
feat(entity): added entity.reset(shallow)

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -325,21 +325,26 @@ export class Entity {
       }
     });
 
-    if (!isNew) {
-      this.setData(this.__cleanValues.data.entity);
-
-      if (!shallow) {
-        let collections = this.__cleanValues.data.collections;
-        Object.getOwnPropertyNames(collections).forEach(index => {
-          this[index] = [];
-          collections[index].forEach(entity => {
-            if (typeof entity === 'number') {
-              this[index].push(entity);
-            }
-          });
-        });
-      }
+    if (isNew) {
+      return this.markClean();
     }
+
+    this.setData(this.__cleanValues.data.entity);
+
+    if (shallow) {
+      return this.markClean();
+    }
+
+    let collections = this.__cleanValues.data.collections;
+
+    Object.getOwnPropertyNames(collections).forEach(index => {
+      this[index] = [];
+      collections[index].forEach(entity => {
+        if (typeof entity === 'number') {
+          this[index].push(entity);
+        }
+      });
+    });
 
     return this.markClean();
   }

--- a/src/entity.js
+++ b/src/entity.js
@@ -290,6 +290,62 @@ export class Entity {
   }
 
   /**
+   * Resets the entity to the clean state
+   *
+   * @param {boolean} [shallow]
+   *
+   * @return {Entity}
+   */
+  reset(shallow) {
+    let pojo     = {};
+    let metadata = this.getMeta();
+
+    Object.keys(this).forEach(propertyName => {
+      let value       = this[propertyName];
+      let association = metadata.fetch('associations', propertyName);
+      
+      // No meta data, no value or no association property: simple assignment.
+      if (!association || !value) {
+        pojo[propertyName] = value;
+
+        return;
+      }
+    })
+
+    if (this.isClean()) {
+      return this;
+    }
+
+    let isNew        = this.isNew();
+    let associations = this.getMeta().fetch('associations');
+
+    Object.keys(this).forEach(propertyName => {
+      if (Object.getOwnPropertyNames(associations).indexOf(propertyName) === -1) {
+        delete this[propertyName];
+      }
+    });
+
+    if (!isNew) {
+      this.setData(this.__cleanValues.data.entity);
+
+      if (!shallow) {
+
+        let collections = this.__cleanValues.data.collections;
+        Object.getOwnPropertyNames(collections).forEach(index => {
+          this[index] = [];
+          collections[index].forEach(entity => {
+            if (typeof entity === 'number') {
+              this[index].push(entity);
+            }
+          });
+        });
+      }
+    }
+
+    return this.markClean();
+  }
+
+  /**
    * Get the resource name of this entity's reference (static).
    *
    * @return {string|null}
@@ -557,7 +613,6 @@ function getCollectionsCompact(forEntity, includeNew) {
     }
 
     collections[index] = [];
-
     if (!Array.isArray(forEntity[index])) {
       return;
     }

--- a/src/entity.js
+++ b/src/entity.js
@@ -303,14 +303,14 @@ export class Entity {
     Object.keys(this).forEach(propertyName => {
       let value       = this[propertyName];
       let association = metadata.fetch('associations', propertyName);
-      
+
       // No meta data, no value or no association property: simple assignment.
       if (!association || !value) {
         pojo[propertyName] = value;
 
         return;
       }
-    })
+    });
 
     if (this.isClean()) {
       return this;
@@ -329,7 +329,6 @@ export class Entity {
       this.setData(this.__cleanValues.data.entity);
 
       if (!shallow) {
-
         let collections = this.__cleanValues.data.collections;
         Object.getOwnPropertyNames(collections).forEach(index => {
           this[index] = [];

--- a/test/entity.spec.js
+++ b/test/entity.spec.js
@@ -336,6 +336,61 @@ describe('Entity', function() {
     });
   });
 
+  describe('.reset()', function() {
+    it('Should properly reset the entity to the clean status including associations', function() {
+      let entity = new WithAssociations();
+
+      entity.setData({
+        id: 667,
+        foo: [{id: 1, value: 'baz'}],
+        bar: {buz: true}
+      }).markClean();
+
+      let checksum = entity.__cleanValues.checksum;
+
+      expect(entity.isDirty()).toBe(false);
+
+      entity.what = 'You dirty, dirty boy.';
+      entity.foo[0].value = 'bazzing';
+
+      expect(entity.isDirty()).toBe(true);
+
+      entity.reset();
+
+      expect(entity.isDirty()).toBe(false);
+      expect(entity.id).toBe(667);
+      expect(entity.foo[0]).toBe(1);
+      expect(entity.bar.buz).toBe(true);
+      expect(entity.__cleanValues.checksum).toBe(checksum);
+    });
+
+    it('Should properly reset the entity to the clean status excluding associations', function() {
+      let entity = new WithAssociations();
+
+      entity.setData({
+        id: 667,
+        foo: [{id: 1, value: 'baz'}],
+        bar: {buz: true}
+      }).markClean();
+      let checksum = entity.__cleanValues.checksum;
+
+      expect(entity.isDirty()).toBe(false);
+
+      entity.what = 'You dirty, dirty boy.';
+      entity.foo[0].value = 'bazzing';
+
+      expect(entity.isDirty()).toBe(true);
+
+      entity.reset(true);
+
+      expect(entity.isDirty()).toBe(false);
+      expect(entity.id).toBe(667);
+      expect(entity.foo[0].value).toBe('bazzing');
+      expect(entity.bar.buz).toBe(true);
+      expect(entity.__cleanValues.checksum).toBe(checksum);
+    });
+  });
+
   describe('.markClean()', function() {
     it('Should properly mark the entity as clean.', function() {
       let entity = new WithResource(new Validation());


### PR DESCRIPTION
only resets collections to their ids instead the entity instance

closes https://github.com/SpoonX/aurelia-orm/issues/84
