### PR TITLE
chore(project): don't concat build

### DIFF
--- a/build/paths.js
+++ b/build/paths.js
@@ -23,7 +23,7 @@ var paths = {
   importsToAdd: [],
   importsToIgnoreForDts: ['extend', 'typer', 'get-prop'],
   sort: true,
-  concat: true,
+  concat: false,
   jsResources: [appRoot + '**/*.js', '!' + appRoot + '*.js'],
   resources: appRoot + '{**/*.css,**/*.html}'
 };


### PR DESCRIPTION
currently the build would be concated. i'd prefer that, but it's not BC. so, reverted that

closes https://github.com/SpoonX/aurelia-orm/issues/159
