### PR TITLE
refactor(association-select): inject Container instead of Entitymanager

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -27,7 +27,7 @@ function cleanGeneratedCode() {
 }
 
 gulp.task('build-index', ['build-resources-index'], function() {
-  var importsToAdd = []; 
+  var importsToAdd = paths.importsToAdd.slice();
 
   var src = gulp.src(paths.mainSource);
 
@@ -54,7 +54,7 @@ gulp.task('build-index', ['build-resources-index'], function() {
     }))
     .pipe(concat(jsName))
     .pipe(insert.transform(function(contents) {
-      return tools.createImportBlock(importsToAdd) + tools.createImportBlock(paths.importsToAdd.slice()) + contents;
+      return tools.createImportBlock(importsToAdd) + contents;
     }))
     .pipe(gulp.dest(paths.output));
 });

--- a/src/component/association-select.js
+++ b/src/component/association-select.js
@@ -1,12 +1,12 @@
 import {logger} from '../aurelia-orm';
 import getProp from 'get-prop';
-import {inject} from 'aurelia-dependency-injection';
+import {inject, Container} from 'aurelia-dependency-injection';
 import {bindingMode, BindingEngine} from 'aurelia-binding';
 import {bindable, customElement} from 'aurelia-templating';
 import {EntityManager, Entity, OrmMetadata} from '../aurelia-orm';
 
 @customElement('association-select')
-@inject(BindingEngine, EntityManager, Element)
+@inject(BindingEngine, Container)
 export class AssociationSelect {
   @bindable criteria;
 
@@ -41,13 +41,12 @@ export class AssociationSelect {
   /**
    * Create a new select element.
    *
-   * @param {BindingEngine} bindingEngine
-   * @param {EntityManager} entityManager
+   * @param {Container} container
    */
-  constructor(bindingEngine, entityManager) {
+  constructor(bindingEngine, container) {
     this._subscriptions = [];
     this.bindingEngine  = bindingEngine;
-    this.entityManager  = entityManager;
+    this.entityManager  = container.get(EntityManager);
   }
 
   /**


### PR DESCRIPTION
injecting internal dependencies can lead to problems with the load order in aurelia-cli resp. jspm. in such a case, the EntitiyManager class isn't defined at the time of @inject evaluation resulting in a DI error.. the only solution i found which worked for both, was to inject the container instead.

closes https://github.com/SpoonX/aurelia-orm/issues/204
