### PR TITLE
chore(build): revert importing for bundling.

### DIFF
--- a/build/paths.js
+++ b/build/paths.js
@@ -21,8 +21,6 @@ var paths = {
   ignore: [],
   useTypeScriptForDTS: false,
   importsToAdd: [
-    "import {AssociationSelect} from './component/association-select';",
-    "import {Paged} from './component/paged';"
   ], // eg. non-concated local imports in the main file as they will get removed during the build process
   importsToIgnoreForDts: ['typer', 'get-prop'], // imports that are only used internally. no need to d.ts export them
   jsResources: [appRoot + 'component/*.js'], // js to transpile, but not be concated and keeping their relative path

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -27,7 +27,7 @@ function cleanGeneratedCode() {
 }
 
 gulp.task('build-index', ['build-resources-index'], function() {
-  var importsToAdd = []; 
+  var importsToAdd = paths.importsToAdd.slice(); 
 
   var src = gulp.src(paths.mainSource);
 
@@ -54,7 +54,7 @@ gulp.task('build-index', ['build-resources-index'], function() {
     }))
     .pipe(concat(jsName))
     .pipe(insert.transform(function(contents) {
-      return tools.createImportBlock(importsToAdd) + tools.createImportBlock(paths.importsToAdd.slice()) + contents;
+      return tools.createImportBlock(importsToAdd) + contents;
     }))
     .pipe(gulp.dest(paths.output));
 });

--- a/src/aurelia-orm.js
+++ b/src/aurelia-orm.js
@@ -3,10 +3,6 @@ import {EntityManager} from './entity-manager';
 import {HasAssociationValidationRule} from './validator/has-association';
 import {ValidationGroup} from 'aurelia-validation';
 
-// added for bundling
-import {AssociationSelect} from './component/association-select'; // eslint-disable-line no-unused-vars
-import {Paged} from './component/paged'; // eslint-disable-line no-unused-vars
-
 export function configure(aurelia, configCallback) {
   let entityManagerInstance = aurelia.container.get(EntityManager);
 


### PR DESCRIPTION
- jspm fails if imported there and bunles correctly anyways
- aurelia-cli has problems with bundling now, but another solution is needed (might work better with aurelia-cli 0.19 and changed install instructions)
