### PR TITLE
fix(component): always parse association-select placeholder as html

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,8 @@ For instance, `@resource()` would use the module's name to set the resource.
 
 So keep in mind: When using aurelia-orm in a bundled application, you must specify a value for your decorators.
 For instance, `@decorator('category')`.
+
+
+## Known hacks
+
+- The association-select always parses the `placeholderText` as html (`t="[html]${placeholderText}"`) due a [aurelia-i18n binding issue](https://github.com/aurelia/i18n/issues/147).

--- a/src/component/association-select.html
+++ b/src/component/association-select.html
@@ -1,6 +1,6 @@
 <template>
   <select class="form-control" value.bind="value" multiple.bind="multiple">
-    <option selected disabled.bind="!hidePlaceholder && !selectablePlaceholder" value="0" show.bind="!hidePlaceholder" t="${placeholderText || '- Select a value -'}">${placeholderText || '- Select a value -'}</option>
+    <option selected disabled.bind="!hidePlaceholder && !selectablePlaceholder" value="0" show.bind="!hidePlaceholder" t="[html]${placeholderText || '- Select a value -'}">${placeholderText || '- Select a value -'}</option>
     <option model.bind="option.id" repeat.for="option of options">${option[property]}</option>
   </select>
 </template>


### PR DESCRIPTION
This is a hack, must be removed when https://github.com/aurelia/i18n/issues/147 is resolved.