### PR TITLE
fix(association-select): use model.bind instead of value.bind

### DIFF
--- a/src/component/association-select.html
+++ b/src/component/association-select.html
@@ -1,6 +1,6 @@
 <template>
   <select class="form-control" value.bind="value" multiple.bind="multiple" disabled.bind="disabled">
-    <option selected disabled.bind="!hidePlaceholder && !selectablePlaceholder" value.bind="placeholderValue" show.bind="!hidePlaceholder" t="[html]${placeholderText || '- Select a value -'}">${placeholderText || '- Select a value -'}</option>
+    <option selected disabled.bind="!hidePlaceholder && !selectablePlaceholder" model.bind="placeholderValue" show.bind="!hidePlaceholder" t="[html]${placeholderText || '- Select a value -'}">${placeholderText || '- Select a value -'}</option>
     <option model.bind="option.id" repeat.for="option of options">${option[property]}</option>
   </select>
 </template>


### PR DESCRIPTION
`value.bind` only accept strings, anything else will be cast to a string.

`null` becomes `"null"`.
https://github.com/aurelia/templating-binding/issues/73

This might be a breaking change, it's possible that people expect a string.