### PR TITLE
feat(assoc-select): add checkbox select view

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -115,6 +115,11 @@ The `property` is the property name of the association on the parent entity.
 ### multiple
 This sets the component to a multi-select. **Defaults to `false`**.
 
+### type
+Some designs prefer checkboxes over a multi-select. The type bindable accepts
+the values `select` or `checkboxes`. It will default to select in case type is
+not defined, or if an invalid type is defined.
+
 ### criteria.bind
 Pass along filter criteria (as JSON or Object) to the element. These will be used to restrict the data returned from the API.
 

--- a/src/component/association-select.html
+++ b/src/component/association-select.html
@@ -1,6 +1,5 @@
 <template>
-  <select class="form-control" value.bind="value" multiple.bind="multiple" disabled.bind="disabled">
-    <option selected disabled.bind="!hidePlaceholder && !selectablePlaceholder" model.bind="placeholderValue" show.bind="!hidePlaceholder" t="[html]${placeholderText || '- Select a value -'}">${placeholderText || '- Select a value -'}</option>
-    <option model.bind="option.id" repeat.for="option of options">${option[property]}</option>
-  </select>
+
+  <compose containerless view.bind="view"> </compose>
+
 </template>

--- a/src/component/association-select.js
+++ b/src/component/association-select.js
@@ -1,8 +1,8 @@
-import getProp from "get-prop";
-import {inject} from "aurelia-dependency-injection";
-import {bindingMode, BindingEngine} from "aurelia-binding";
-import {bindable, customElement} from "aurelia-templating";
-import {logger, EntityManager, Entity, OrmMetadata} from "../aurelia-orm";
+import getProp from 'get-prop';
+import {inject} from 'aurelia-dependency-injection';
+import {bindingMode, BindingEngine, computedFrom} from 'aurelia-binding';
+import {bindable, customElement} from 'aurelia-templating';
+import {logger, EntityManager, Entity, OrmMetadata} from '../aurelia-orm';
 
 @customElement('association-select')
 @inject(BindingEngine, EntityManager, Element)
@@ -39,6 +39,8 @@ export class AssociationSelect {
 
   @bindable placeholderText;
 
+  @bindable type = "select";
+
   ownMeta;
 
   /**
@@ -51,6 +53,16 @@ export class AssociationSelect {
     this._subscriptions = [];
     this.bindingEngine  = bindingEngine;
     this.entityManager  = entityManager;
+  }
+
+  typeAliases = {
+    checkboxes: 'checkboxes',
+    select    : 'select',
+  };
+
+  @computedFrom('type')
+  get view() {
+    return `./${this.typeAliases[this.type] || 'select'}.html`;
   }
 
   /**

--- a/src/component/checkboxes.html
+++ b/src/component/checkboxes.html
@@ -1,0 +1,16 @@
+<template>
+
+  <template containerless repeat.for="option of options">
+    <div class="checkbox">
+      <label>
+        <input
+        type="checkbox"
+        name.bind="option[property]"
+        model.bind="option.id"
+        checked.bind="value">
+        ${option[property]}
+      </label>
+    </div>
+  </template>
+
+</template>

--- a/src/component/select.html
+++ b/src/component/select.html
@@ -1,0 +1,6 @@
+<template>
+  <select class="form-control" value.bind="value" multiple.bind="multiple" disabled.bind="disabled">
+    <option selected disabled.bind="!hidePlaceholder && !selectablePlaceholder" model.bind="placeholderValue" show.bind="!hidePlaceholder" t="[html]${placeholderText || '- Select a value -'}">${placeholderText || '- Select a value -'}</option>
+    <option model.bind="option.id" repeat.for="option of options">${option[property]}</option>
+  </select>
+</template>


### PR DESCRIPTION
- [x] create a checkboxes view
- [x] move the select to a seperate view
- [x] define the `type` bindable
- [x] use compose to select the correct view depending on the type bindable
- [x] computed view property that calculates the view path
- [x] document type bindable
- [x] add association select type to `aurelia-form`