### PR TITLE
Fix association-select selected disabled placeholder

### DIFF
--- a/src/component/association-select.html
+++ b/src/component/association-select.html
@@ -1,5 +1,5 @@
 <template>
-  <select class="form-control" value.bind="value" multiple.bind="multiple" disabled.bind="disabled">
+  <select class="form-control" model.bind="value" multiple.bind="multiple" disabled.bind="disabled">
     <option selected disabled.bind="!hidePlaceholder && !selectablePlaceholder" model.bind="placeholderValue" show.bind="!hidePlaceholder" t="[html]${placeholderText || '- Select a value -'}">${placeholderText || '- Select a value -'}</option>
     <option model.bind="option.id" repeat.for="option of options">${option[property]}</option>
   </select>

--- a/src/component/association-select.html
+++ b/src/component/association-select.html
@@ -1,6 +1,6 @@
 <template>
   <select class="form-control" model.bind="value" multiple.bind="multiple" disabled.bind="disabled">
-    <option selected disabled.bind="!hidePlaceholder && !selectablePlaceholder" model.bind="placeholderValue" show.bind="!hidePlaceholder" t="[html]${placeholderText || '- Select a value -'}">${placeholderText || '- Select a value -'}</option>
+    <option selected disabled.bind="!hidePlaceholder && !selectablePlaceholder" model.bind="placeholderValue" show.bind="showPlaceholder" t="[html]${placeholderText || '- Select a value -'}">${placeholderText || '- Select a value -'}</option>
     <option model.bind="option.id" repeat.for="option of options">${option[property]}</option>
   </select>
 </template>

--- a/src/component/association-select.js
+++ b/src/component/association-select.js
@@ -29,7 +29,7 @@ export class AssociationSelect {
 
   @bindable multiple = false;
 
-  @bindable hidePlaceholder = false;
+  @bindable hidePlaceholder;
 
   @bindable selectablePlaceholder = false;
 
@@ -40,6 +40,10 @@ export class AssociationSelect {
   @bindable placeholderText;
 
   ownMeta;
+
+  get showPlaceholder() {
+    return !((typeof this.hidePlaceholder === 'boolean') ? this.hidePlaceholder : this.multiple);
+  }
 
   /**
    * Create a new select element.

--- a/src/component/association-select.js
+++ b/src/component/association-select.js
@@ -33,7 +33,7 @@ export class AssociationSelect {
 
   @bindable selectablePlaceholder = false;
 
-  @bindable placeholderValue = 0;
+  @bindable placeholderValue = null;
 
   @bindable disabled = false;
 


### PR DESCRIPTION
Fixes `association-select`'s placeholder so that it's `disabled` and `selected` by default. Classic case of `null != "null"`.