### PR TITLE
doc(installation): Fix cli configuration

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -6,12 +6,13 @@ Aurelia-orm needs an installation of [aurelia-api](https://www.npmjs.com/package
 
 Run `npm i aurelia-orm --save` from your project root.
 
-It also has submodules and makes use of `get-prop`. So, add following to the `build.bundles.dependencies` section of `aurelia-project/aurelia.json`.
+It also has submodules and makes use of `get-prop` and `typer`. So, add following to the `build.bundles.dependencies` section of `aurelia-project/aurelia.json`.
 
 ```js
 "dependencies": [
   // ...
   "get-prop",
+  "typer",
   {
     "name": "aurelia-orm",
     "path": "../node_modules/aurelia-orm/dist/amd",
@@ -24,7 +25,7 @@ It also has submodules and makes use of `get-prop`. So, add following to the `bu
   {
     "name": "aurelia-validation",
     "path": "../node_modules/aurelia-validation/dist/amd",
-    "main": "index"
+    "main": "aurelia-validation"
   },
   // ...
 ],


### PR DESCRIPTION
The main of aurelia-validation is `aurelia-validation`, not `index`.
Also, the dependency on typer was undocumented.

I currently do not have jspm set up anywhere so I can't check that section on the typer dependency