### PR TITLE
feat(repository): validate dates before casting

### DIFF
--- a/src/repository.js
+++ b/src/repository.js
@@ -181,8 +181,19 @@ export class Repository {
       let value = data[key];
 
       if (entityMetadata.has('types', key)) {
-        populatedData[key] = typer.cast(value, entityMetadata.fetch('types', key));
+        
+        var entityType =  entityMetadata.fetch('types', key);
 
+        if(entityType === 'Date')
+        {
+          if(value){
+            populatedData[key] = typer.default.cast(value, entityType);
+          }
+        }
+        else{
+           populatedData[key] = typer.default.cast(value, entityType);
+        }
+                
         continue;
       }
 

--- a/src/repository.js
+++ b/src/repository.js
@@ -181,17 +181,15 @@ export class Repository {
       let value = data[key];
 
       if (entityMetadata.has('types', key)) {
-        
-        var entityType =  entityMetadata.fetch('types', key);
-
-        if(entityType === 'Date')
+       var dataType =  entityMetadata.fetch('types', key);
+       if(dataType === 'date' || dataType === 'datetime')
         {
           if(value){
-            populatedData[key] = typer.default.cast(value, entityType);
+            populatedData[key] = typer.default.cast(value, dataType);
           }
         }
         else{
-           populatedData[key] = typer.default.cast(value, entityType);
+           populatedData[key] = typer.default.cast(value, dataType);
         }
                 
         continue;


### PR DESCRIPTION
The motivation for the change is that an entity with a date property would end up with a date, even if it was null.  So a null date would show up as 1/1/1970.  

The desired behavior is that a null date in the database would show up on the client as null.
