### PR TITLE
Fix identifier on association-select

### DIFF
--- a/src/component/view/bootstrap/association-select.html
+++ b/src/component/view/bootstrap/association-select.html
@@ -1,6 +1,6 @@
 <template>
   <select name.bind="name" class="form-control" value.bind="value" multiple.bind="multiple" disabled.bind="disabled">
     <option selected disabled.bind="!hidePlaceholder && !selectablePlaceholder" model.bind="placeholderValue" show.bind="!hidePlaceholder" t="[html]${placeholderText || '- Select a value -'}">${placeholderText || '- Select a value -'}</option>
-    <option model.bind="option.id" repeat.for="option of options">${option[property]}</option>
+    <option model.bind="option[identifier]" repeat.for="option of options">${option[property]}</option>
   </select>
 </template>


### PR DESCRIPTION
There are some problems with `association-select` when the identifier of an entity is not contained in the key named `id`.